### PR TITLE
build: add Makefile artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 /telegraf.exe
 /telegraf.gz
 /vendor
+
+.update-modules
+.update-telegraf-deps


### PR DESCRIPTION
This change prevents the project from being marked marked as dirty by
git after running make.
