### PR TITLE
feat: set lotus_info from lotus plugin at startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	github.com/kubernetes/apimachinery v0.0.0-20190119020841-d41becfba9ee
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 // indirect
+	github.com/libp2p/go-libp2p-core v0.6.0
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/mdlayher/apcupsd v0.0.0-20190314144147-eb3dd99a75fe
 	github.com/miekg/dns v1.1.28

--- a/plugins/inputs/lotus/lotus.go
+++ b/plugins/inputs/lotus/lotus.go
@@ -479,20 +479,13 @@ func recordLotusInfoPoints(ctx context.Context, api api.FullNode, acc telegraf.A
 	if err != nil {
 		return err
 	}
+	versionTokens := strings.SplitN(v.Version, "+", 2)
+	version := versionTokens[0]
+	commit := versionTokens[1]
 
 	network, err := api.StateNetworkName(ctx)
 	if err != nil {
 		return err
-	}
-	var commit string
-	var version string
-	versionTokens := strings.Split(v.Version, "+")
-	if len(versionTokens) == 2 {
-		version = versionTokens[0]
-		commit = versionTokens[1]
-	} else {
-		log.Println("W! developer error, version string has changed format")
-		version = v.Version
 	}
 
 	acc.AddFields("lotus_info",

--- a/plugins/inputs/lotus/lotus.go
+++ b/plugins/inputs/lotus/lotus.go
@@ -496,9 +496,7 @@ func recordLotusInfoPoints(ctx context.Context, api api.FullNode, acc telegraf.A
 	}
 
 	acc.AddFields("lotus_info",
-		map[string]interface{}{
-			"recorded_at": time.Now().UnixNano(),
-		},
+		map[string]interface{}{},
 		map[string]string{
 			"api_version": v.APIVersion.String(),
 			"commit":      commit,


### PR DESCRIPTION
Makes progress towards: https://github.com/filecoin-project/sentinel/issues/34
(need to stop the Prometheus gathering via a config change over in sentinel land)