### PR TITLE
feat: add lotus_peer_id processor plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/armon/go-metrics v0.3.0 // indirect
 	github.com/aws/aws-sdk-go v1.32.11
 	github.com/bitly/go-hostpool v0.1.0 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/caio/go-tdigest v2.3.0+incompatible // indirect
 	github.com/cisco-ie/nx-telemetry-proto v0.0.0-20190531143454-82441e232cf6
 	github.com/cockroachdb/apd v1.1.0 // indirect
@@ -81,6 +81,7 @@ require (
 	github.com/kubernetes/apimachinery v0.0.0-20190119020841-d41becfba9ee
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 // indirect
+	github.com/libp2p/go-libp2p-core v0.6.1
 	github.com/matttproud/golang_protobuf_extensions v1.0.1
 	github.com/mdlayher/apcupsd v0.0.0-20190314144147-eb3dd99a75fe
 	github.com/miekg/dns v1.1.30

--- a/plugins/processors/all/all.go
+++ b/plugins/processors/all/all.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/processors/date"
 	_ "github.com/influxdata/telegraf/plugins/processors/dedup"
 	_ "github.com/influxdata/telegraf/plugins/processors/enum"
+	_ "github.com/influxdata/telegraf/plugins/processors/lotus_peer_id"
 	_ "github.com/influxdata/telegraf/plugins/processors/override"
 	_ "github.com/influxdata/telegraf/plugins/processors/parser"
 	_ "github.com/influxdata/telegraf/plugins/processors/pivot"

--- a/plugins/processors/lotus_peer_id/README.md
+++ b/plugins/processors/lotus_peer_id/README.md
@@ -1,0 +1,37 @@
+# Lotus Peer ID Processor Plugin
+
+The `lotus_peer_id` processor tags measurements with the configured lotus node's libp2p PeerID.
+
+### Configuration:
+
+```toml
+[[processors.lotus_peer_id]]
+    ## Provide the Lotus working path. The input plugin will scan the path contents
+    ## for the correct listening address/port and API token. Note: Path must be readable
+    ## by the telegraf process otherwise, the value should be manually set in api_listen_addr
+    ## and api_token. This value is ignored if lotus_api_* values are populated.
+    ## Default: "${HOME}/.lotus"
+    lotus_datapath = "${HOME}/.lotus"
+
+    ## Provide the token that telegraf can use to access the lotus API. The token only requires
+    ## "read" privileges. This is useful for restricting metrics to a seperate token.
+    # lotus_api_token = ""
+
+    ## Provide the multiaddr that the lotus API is listening on. If API multiaddr is empty,
+    ## telegraf will check lotus_datapath for values.
+    ## Default: "/ip4/0.0.0.0/tcp/1234"
+    # lotus_api_multiaddr = "/ip4/0.0.0.0/tcp/1234"
+
+    ## Provide the measurments that should be excluded from receiving a peer_id tag.
+    # exclude = [
+    #    "metric_name_to_exclude",
+    # ]
+
+```
+
+### Example processing:
+
+```diff
+- measurement1,tag1=foo,tag2=bar field1=1i,field2=2.1 1453831884664956455
++ measurement1,tag1=foo,tag2=bar,peer_id=12D3KooWPbdJEL5wV2MWxgHRwyUnWgnNA2jknBH9J7re8Krw4hyW field1=1i,field2=2.1 1453831884664956455
+```

--- a/plugins/processors/lotus_peer_id/peerid.go
+++ b/plugins/processors/lotus_peer_id/peerid.go
@@ -1,0 +1,143 @@
+package lotus_peer_id
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/plugins/inputs/lotus/rpc"
+	"github.com/influxdata/telegraf/plugins/processors"
+
+	"github.com/filecoin-project/lotus/api"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+const (
+	DefaultConfig_DataPath      = "${HOME}/.lotus"
+	DefaultConfig_APIListenAddr = "/ip4/0.0.0.0/tcp/1234"
+)
+
+var sampleConfig = fmt.Sprintf(`
+	## Provide the multiaddr that the lotus API is listening on. If API multiaddr is empty,
+	## telegraf will check lotus_datapath for values. Default: "%[1]s"
+	# lotus_api_multiaddr = "%[1]s"
+
+	## Provide the token that telegraf can use to access the lotus API. The token only requires
+	## "read" privileges. This is useful for restricting metrics to a seperate token.
+	# lotus_api_token = ""
+
+	## Provide the Lotus working path. The input plugin will scan the path contents
+	## for the correct listening address/port and API token. Note: Path must be readable
+	## by the telegraf process otherwise, the value should be manually set in api_listen_addr
+	## and api_token. This value is ignored if lotus_api_* values are populated.
+	## Default: "%[2]s"
+	lotus_datapath = "%[2]s"
+
+`, DefaultConfig_DataPath, DefaultConfig_APIListenAddr)
+
+type Exclude struct {
+	Measurement string `toml:"measurement"`
+}
+
+type LotusPeerIDTagger struct {
+	Config_DataPath      string `toml:"lotus_datapath"`
+	Config_APIListenAddr string `toml:"lotus_api_multiaddr"`
+	Config_APIToken      string `toml:"lotus_api_token"`
+
+	Excludes []Exclude `toml:"exclude"`
+
+	excludeMap map[string]struct{}
+
+	peerID peer.ID
+}
+
+func (l *LotusPeerIDTagger) setDefaults() {
+	if len(l.Config_DataPath) == 0 {
+		l.Config_DataPath = DefaultConfig_DataPath
+	}
+	if len(l.Config_APIListenAddr) == 0 {
+		l.Config_APIListenAddr = DefaultConfig_APIListenAddr
+	}
+}
+
+func (l *LotusPeerIDTagger) setPeerID() {
+	nodeAPI, nodeCloser, err := l.getAPIUsingLotusConfig()
+	if err != nil {
+		log.Println("E! Failed to get lotus api", "error", err.Error())
+		return
+	}
+	defer nodeCloser()
+	pid, err := nodeAPI.ID(context.Background())
+	if err != nil {
+		log.Println("E! Failed to get lotus peer ID", "error", err.Error())
+		return
+	}
+	l.peerID = pid
+}
+
+func (l *LotusPeerIDTagger) setExcludeMap() {
+	ex := make(map[string]struct{})
+	for _, e := range l.Excludes {
+		ex[e.Measurement] = struct{}{}
+	}
+	l.excludeMap = ex
+}
+
+func (l *LotusPeerIDTagger) getAPIUsingLotusConfig() (api.FullNode, func(), error) {
+	var (
+		nodeAPI    api.FullNode
+		nodeCloser func()
+	)
+	if len(l.Config_APIListenAddr) > 0 && len(l.Config_APIToken) > 0 {
+		api, apiCloser, err := rpc.GetFullNodeAPIUsingCredentials(l.Config_APIListenAddr, l.Config_APIToken)
+		if err != nil {
+			err = fmt.Errorf("connect with credentials: %v", err)
+			return nil, nil, err
+		}
+		nodeAPI = api
+		nodeCloser = apiCloser
+	} else {
+		api, apiCloser, err := rpc.GetFullNodeAPI(l.Config_DataPath)
+		if err != nil {
+			err = fmt.Errorf("connect from lotus state: %v", err)
+			return nil, nil, err
+		}
+		nodeAPI = api
+		nodeCloser = apiCloser
+	}
+	return nodeAPI, nodeCloser, nil
+}
+
+func (l *LotusPeerIDTagger) SampleConfig() string {
+	return sampleConfig
+}
+
+func (l *LotusPeerIDTagger) Description() string {
+	return "Decorate measurements that pass through this filter with the peer id of lotus daemon."
+}
+
+func (l *LotusPeerIDTagger) Apply(in ...telegraf.Metric) []telegraf.Metric {
+	if l.peerID.Size() == 0 {
+		log.Println("Setting up lotus_peer_id processor")
+		// configure lotus connection
+		l.setDefaults()
+		// extract peerID from connected lotus daemon
+		l.setPeerID()
+		// create mapping of excluded metrics for faster processing.
+		l.setExcludeMap()
+	}
+
+	for _, point := range in {
+		if _, exclude := l.excludeMap[point.Name()]; !exclude {
+			point.AddTag("lotus_peer_id", l.peerID.String())
+		}
+	}
+	return in
+}
+
+func init() {
+	processors.Add("lotus_peer_id", func() telegraf.Processor {
+		return &LotusPeerIDTagger{}
+	})
+}

--- a/plugins/processors/lotus_peer_id/peerid_test.go
+++ b/plugins/processors/lotus_peer_id/peerid_test.go
@@ -1,0 +1,47 @@
+package lotus_peer_id
+
+import (
+	"github.com/bmizerany/assert"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/metric"
+)
+
+func newMetric(name string, tags map[string]string, fields map[string]interface{}) telegraf.Metric {
+	if tags == nil {
+		tags = map[string]string{}
+	}
+	if fields == nil {
+		fields = map[string]interface{}{}
+	}
+	m, _ := metric.New(name, tags, fields, time.Now())
+	return m
+}
+
+func TestTagMetricWithPeerID(t *testing.T) {
+	pid, err := peer.Decode("12D3KooWRHNnsJmKEsJwqxesunwuQXS4V7n74PoK6Ca5NJ87bUcu")
+	require.NoError(t, err)
+
+	p := LotusPeerIDTagger{
+		peerID: pid, // setting the peerID causes LotusPeerIDTagger to skip api init allowing Apply to be called
+		Excludes:             []Exclude{
+			{Measurement: "bar"}, // we will ignore measures with this name
+		},
+	}
+
+	includeM := newMetric("foo", map[string]string{"hostname": "localhost", "region": "earth"}, nil)
+	result := p.Apply(includeM)
+	require.Len(t, result, 1)
+	assert.Equal(t, map[string]string{"hostname": "localhost", "region": "earth", "lotus_peer_id": pid.String()},result[0].Tags())
+
+	excludeM := newMetric("bar", map[string]string{"hostname": "localhost", "region": "earth"}, nil)
+	result = p.Apply(excludeM)
+	require.Len(t, result, 1)
+	assert.Equal(t, map[string]string{"hostname": "localhost", "region": "earth"},result[0].Tags())
+
+}

--- a/plugins/processors/lotus_peer_id/peerid_test.go
+++ b/plugins/processors/lotus_peer_id/peerid_test.go
@@ -29,7 +29,7 @@ func TestTagMetricWithPeerID(t *testing.T) {
 
 	p := LotusPeerIDTagger{
 		peerID: pid, // setting the peerID causes LotusPeerIDTagger to skip api init allowing Apply to be called
-		Excludes:             []Exclude{
+		Config_Excluded:             []Exclude{
 			{Measurement: "bar"}, // we will ignore measures with this name
 		},
 	}


### PR DESCRIPTION
- Adds lotus peerid as tag to metrics
- includes unit test
- closes https://github.com/filecoin-project/sentinel/issues/34