### PR TITLE
fix(input/louts_plugin): requires > 0 metrics

### DIFF
--- a/plugins/inputs/lotus/lotus.go
+++ b/plugins/inputs/lotus/lotus.go
@@ -295,7 +295,9 @@ func (l *lotus) recordLotusInfoPoints(ctx context.Context, acc telegraf.Accumula
 	}
 
 	acc.AddFields("lotus_info",
-		map[string]interface{}{},
+		map[string]interface{}{
+		"nothing": 0,
+		},
 		map[string]string{
 			"api_version": v.APIVersion.String(),
 			"commit":      commit,


### PR DESCRIPTION
Noticed some cases where lotus_info is not pushing updates to outputs. This should ensure there's a dummy metric value being sent with the fields.