### PR TITLE
Remove Mpool Tracking; Adjust Metrics Names

### DIFF
--- a/plugins/inputs/lotus/lotus.go
+++ b/plugins/inputs/lotus/lotus.go
@@ -340,14 +340,21 @@ func (l *lotus) processHeader(ctx context.Context, acc telegraf.Accumulator, new
 }
 
 func recordBlockHeaderPoints(ctx context.Context, acc telegraf.Accumulator, newHeader *types.BlockHeader, receivedAt time.Time) error {
+	var parentBlocks = ""
+	for _, cid := range newHeader.Parents {
+		parentBlocks += cid.String() + ","
+	}
 	acc.AddFields("observed_headers",
 		map[string]interface{}{
 			"tipset_height":    newHeader.Height,
 			"header_timestamp": time.Unix(int64(newHeader.Timestamp), 0).Unix(),
 		},
 		map[string]string{
-			"header_cid": newHeader.Cid().String(),
-			"miner_id":   newHeader.Miner.String(),
+			"header_cid":        newHeader.Cid().String(),
+			"miner_id":          newHeader.Miner.String(),
+			"parent_state_root": newHeader.ParentStateRoot.String(),
+			"parent_weight":     newHeader.ParentWeight.String(),
+			"parents":           parentBlocks,
 		},
 		receivedAt)
 	return nil

--- a/plugins/inputs/lotus/lotus.go
+++ b/plugins/inputs/lotus/lotus.go
@@ -3,7 +3,6 @@ package lotus
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -268,7 +267,7 @@ func (l *lotus) recordLotusInfoPoints(ctx context.Context, acc telegraf.Accumula
 		return err
 	}
 
-	acc.AddFields("lotus_info",
+	acc.AddFields("observed_info",
 		map[string]interface{}{
 			"nothing": 0,
 		},
@@ -341,22 +340,14 @@ func (l *lotus) processHeader(ctx context.Context, acc telegraf.Accumulator, new
 }
 
 func recordBlockHeaderPoints(ctx context.Context, acc telegraf.Accumulator, newHeader *types.BlockHeader, receivedAt time.Time) error {
-	bs, err := newHeader.Serialize()
-	if err != nil {
-		return err
-	}
-	acc.AddFields("chain_block",
+	acc.AddFields("observed_headers",
 		map[string]interface{}{
 			"tipset_height":    newHeader.Height,
-			"election":         1,
-			"header_size":      len(bs),
-			"header_timestamp": time.Unix(int64(newHeader.Timestamp), 0).UnixNano(),
-			"recorded_at":      receivedAt.UnixNano(),
+			"header_timestamp": time.Unix(int64(newHeader.Timestamp), 0).Unix(),
 		},
 		map[string]string{
-			"header_cid_tag":    newHeader.Cid().String(),
-			"tipset_height_tag": strconv.Itoa(int(newHeader.Height)),
-			"miner_tag":         newHeader.Miner.String(),
+			"header_cid": newHeader.Cid().String(),
+			"miner_id":   newHeader.Miner.String(),
 		},
 		receivedAt)
 	return nil
@@ -369,13 +360,15 @@ func recordTipsetMessagesPoints(ctx context.Context, acc telegraf.Accumulator, t
 		return fmt.Errorf("no cids in tipset")
 	}
 
-	acc.AddFields("chain_tipset",
+	acc.AddFields("observed_tipsets",
 		map[string]interface{}{
-			"recorded_at":   receivedAt.UnixNano(),
 			"tipset_height": int(tipset.Height()),
 			"block_count":   len(cids),
+			"recorded_at":   receivedAt.UnixNano(),
 		},
-		map[string]string{}, ts)
+		map[string]string{
+			"tipset_key": tipset.Key().String(),
+		}, ts)
 
 	return nil
 }


### PR DESCRIPTION
Mpool tracking is too expensive.
Lotus input metric names start with `observed_`.

Concerns for discussion:
- This removes mpool per message tracking across all nodes. It might be better to capture aggregate data on this instead of per message data? (ex: https://github.com/filecoin-project/lotus/blob/master/cmd/lotus-shed/mempool-stats.go)
- This is the first change which will require a migration in drone (alongside the separate migration concerns of visor). I'm thinking of a pattern we can adopt to make sure migrations between components are independently managed but coordinated at install-time. Need good pattern here and haven't decided on the approach yet.