### PR TITLE
chore: Include RC releases in push docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,18 +78,14 @@ workflows:
       - docker-build:
           filters:
             branches:
-              only:
-                - master
-                - main
-                - /.*-master$/
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*/  # incl v0.0.0 or v0.0.0-rc0
       - docker-push:
           requires:
             - docker-build
           filters:
             branches:
-              only:
-                - master
-                - main
-                - /^[a-z]*-master$/
+              ignore: /.*/
             tags:
-              only: /^v[0-9].*/
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*/  # incl v0.0.0 or v0.0.0-rc0


### PR DESCRIPTION
Update CI to:
- no longer build docker images on all commits to master or branches
- include RC tags in docker builds/pushes